### PR TITLE
fix(hw): swap C6/C17 cap placement

### DIFF
--- a/hardware/MitsubishiSC.kicad_pcb
+++ b/hardware/MitsubishiSC.kicad_pcb
@@ -9263,7 +9263,7 @@
 	(footprint "Capacitor_SMD:C_0603_1608Metric"
 		(layer "F.Cu")
 		(uuid "91e13e12-1bb2-4a32-b87b-91a92c84dab3")
-		(at 152.15 104 90)
+		(at 155.15 104 90)
 		(descr "Capacitor SMD 0603 (1608 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: IPC-SM-782 page 76, https://www.pcb-3d.com/wordpress/wp-content/uploads/ipc-sm-782a_amendment_1_and_2.pdf), generated with kicad-footprint-generator")
 		(tags "capacitor")
 		(property "Reference" "C17"
@@ -11777,7 +11777,7 @@
 	(footprint "Capacitor_SMD:C_0603_1608Metric"
 		(layer "F.Cu")
 		(uuid "abbcb4d9-662c-48f5-8bbf-7e861925b13c")
-		(at 155.15 104 90)
+		(at 152.15 104 90)
 		(descr "Capacitor SMD 0603 (1608 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: IPC-SM-782 page 76, https://www.pcb-3d.com/wordpress/wp-content/uploads/ipc-sm-782a_amendment_1_and_2.pdf), generated with kicad-footprint-generator")
 		(tags "capacitor")
 		(property "Reference" "C6"


### PR DESCRIPTION
This commit fixes an issue with the SMPS output cap placement where the
100nF capacitor should have been placed closest to the pins but is not
the case.
