### PR TITLE
feat(hw): reduce LED brightness

### DIFF
--- a/hardware/MitsubishiSC.kicad_pcb
+++ b/hardware/MitsubishiSC.kicad_pcb
@@ -10170,7 +10170,7 @@
 				)
 			)
 		)
-		(property "Value" "1kR"
+		(property "Value" "10kR"
 			(at 0 1.43 0)
 			(layer "F.Fab")
 			(uuid "85b95e1b-e212-4aed-9a43-38c7c0d70e9f")
@@ -10181,7 +10181,7 @@
 				)
 			)
 		)
-		(property "Datasheet" "https://www.lcsc.com/datasheet/lcsc_datasheet_2304140030_YAGEO-RC0603FR-071KL_C22548.pdf"
+		(property "Datasheet" "https://www.lcsc.com/datasheet/lcsc_datasheet_2304140030_YAGEO-RC0603FR-0710KL_C98220.pdf"
 			(at 0 0 180)
 			(unlocked yes)
 			(layer "F.Fab")
@@ -10220,7 +10220,7 @@
 				)
 			)
 		)
-		(property "Distributor Part Number" "C22548"
+		(property "Distributor Part Number" "C98220"
 			(at 0 0 180)
 			(unlocked yes)
 			(layer "F.Fab")
@@ -10246,7 +10246,7 @@
 				)
 			)
 		)
-		(property "Manufacturer Part Number" "RC0603FR-071KL"
+		(property "Manufacturer Part Number" "RC0603FR-0710KL"
 			(at 0 0 180)
 			(unlocked yes)
 			(layer "F.Fab")

--- a/hardware/MitsubishiSC.kicad_sch
+++ b/hardware/MitsubishiSC.kicad_sch
@@ -8149,7 +8149,7 @@
 				(justify left)
 			)
 		)
-		(property "Value" "1kR"
+		(property "Value" "10kR"
 			(at 203.2 140.9699 0)
 			(effects
 				(font
@@ -8167,7 +8167,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" "https://www.lcsc.com/datasheet/lcsc_datasheet_2304140030_YAGEO-RC0603FR-071KL_C22548.pdf"
+		(property "Datasheet" "https://www.lcsc.com/datasheet/lcsc_datasheet_2304140030_YAGEO-RC0603FR-0710KL_C98220.pdf"
 			(at 200.66 139.7 0)
 			(effects
 				(font
@@ -8194,7 +8194,7 @@
 				(hide yes)
 			)
 		)
-		(property "Distributor Part Number" "C22548"
+		(property "Distributor Part Number" "C98220"
 			(at 200.66 139.7 0)
 			(effects
 				(font
@@ -8212,7 +8212,7 @@
 				(hide yes)
 			)
 		)
-		(property "Manufacturer Part Number" "RC0603FR-071KL"
+		(property "Manufacturer Part Number" "RC0603FR-0710KL"
 			(at 200.66 139.7 0)
 			(effects
 				(font


### PR DESCRIPTION
This commit reduces the brightness of the indicator LED by increasing
the resistor value of R8 from 1kR to 10kR. Although the resistor value
is on the higher side, this is generally fine because the use of LED is
not user-facing.
